### PR TITLE
Minor updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To push to an upstream branch other than `trigger-integration`, set:
 
     export GPF_UPSTREAM_BRANCH=my-custom-branch-name
 
-To push code to the upstream branch via ssh rather than the default of https, set:
+To push code to the upstream branch via SSH rather than the default of HTTPS, set:
 
     export GPF_USE_SSH=true
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ git-push-fork-to-upstream-branch upstream jklukas:new-feature
 That invocation assumes that your remote is named `upstream` and it copies in
 the `username:branch` from the PR; note that GitHub includes a handy button
 right next to that text for copying to the clipboard and pasting to this command.
-The code has now been pushed to the `trigger-integration`and because this is
+The code has now been pushed to the `trigger-integration` and because this is
 exactly the same commit (with the same hash) as on the forked repository, most
 CI systems will trigger a build that GitHub then associates with the forked PR.
 You should see status change in the PR to indicate that a new build is running.


### PR DESCRIPTION
This is mostly so our GitHub repository auto-archival logic no longer considers this an inactive repository ([it's still used in `bigquery-etl`](https://github.com/mozilla/bigquery-etl/blob/1a547e5dc7153118719c566ad16121b3435402b2/.github/workflows/push-to-upstream.yml#L29)).